### PR TITLE
Fix VR compilation

### DIFF
--- a/src/DRS.cpp
+++ b/src/DRS.cpp
@@ -33,7 +33,10 @@ void DRS::GetGameSettings()
 {
 	auto ini = RE::INISettingCollection::GetSingleton();
 	bEnableAutoDynamicResolution = ini->GetSetting("bEnableAutoDynamicResolution:Display");
-	bEnableAutoDynamicResolution->data.b = true;
+	if (bEnableAutoDynamicResolution)
+		bEnableAutoDynamicResolution->data.b = true;
+	else
+		logger::warn("Unable to enable Dynamic Resolution, please enable manually.");
 }
 
 void DRS::Update()

--- a/src/DRS.cpp
+++ b/src/DRS.cpp
@@ -31,10 +31,12 @@ void DRS::LoadINI()
 
 void DRS::GetGameSettings()
 {
-	auto ini = RE::INISettingCollection::GetSingleton();
-	bEnableAutoDynamicResolution = ini->GetSetting("bEnableAutoDynamicResolution:Display");
-	if (bEnableAutoDynamicResolution)
+	bEnableAutoDynamicResolution = RE::GetINISetting("bEnableAutoDynamicResolution:Display");
+	if (bEnableAutoDynamicResolution) {
+		if (!bEnableAutoDynamicResolution->GetBool())
+			logger::info("Forcing DynamicResolution on.");
 		bEnableAutoDynamicResolution->data.b = true;
+	}
 	else
 		logger::warn("Unable to enable Dynamic Resolution, please enable manually.");
 }

--- a/src/DRS.h
+++ b/src/DRS.h
@@ -136,7 +136,7 @@ protected:
 
 		static void Install()
 		{
-			stl::write_thunk_call<Main_SetDRS>(REL::RelocationID(35556, 36555).address() + REL::Relocate(0x2D, 0x2D));
+			stl::write_thunk_call<Main_SetDRS>(REL::RelocationID(35556, 36555).address() + REL::Relocate(0x2D, 0x2D, 0x25));
 			stl::write_thunk_call<Main_Update_Start>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x1E, 0x3E, 0x33));
 			stl::write_thunk_call<Main_Update_Render>(REL::RelocationID(35565, 36564).address() + REL::Relocate(0x5D2, 0xA92, 0x678));
 		}


### PR DESCRIPTION
For some reason the ini setting is nullptr in VR. I checked the strings and addresses in commonlib and it should be accessible, but I figured this should be enough.