### PR TITLE
Control resolution after Fader Menu closes

### DIFF
--- a/src/DRS.cpp
+++ b/src/DRS.cpp
@@ -38,9 +38,12 @@ void DRS::GetGameSettings()
 
 void DRS::Update()
 {
-	if (reset)
+	if (reset) {	
 		ResetScale();
-	else if (!(RE::UI::GetSingleton() && RE::UI::GetSingleton()->GameIsPaused()))  // Ignore paused game which skews frametimes
+		return;
+	}
+
+	if (!(RE::UI::GetSingleton() && RE::UI::GetSingleton()->GameIsPaused()))  // Ignore paused game which skews frametimes
 		ControlResolution();
 }
 
@@ -171,12 +174,13 @@ void DRS::UpdateCPUFrameTime()
 
 RE::BSEventNotifyControl MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
 {
-	if (a_event->menuName == "Loading Menu") {
-		if (a_event->opening) {
+	if (a_event->menuName == RE::LoadingMenu::MENU_NAME) {
+		if (a_event->opening)
 			DRS::GetSingleton()->reset = true;
-		} else {
+	}
+	else if (a_event->menuName == RE::FaderMenu::MENU_NAME) {
+		if (!a_event->opening)
 			DRS::GetSingleton()->reset = false;
-		}
 	}
 
 	return RE::BSEventNotifyControl::kContinue;

--- a/src/DRS.cpp
+++ b/src/DRS.cpp
@@ -40,7 +40,8 @@ void DRS::Update()
 {
 	if (reset) {	
 		ResetScale();
-		return;
+		if (auto ui = RE::UI::GetSingleton(); ui && ui->IsUsingCustomRendering())
+			return;
 	}
 
 	if (!(RE::UI::GetSingleton() && RE::UI::GetSingleton()->GameIsPaused()))  // Ignore paused game which skews frametimes
@@ -181,6 +182,9 @@ RE::BSEventNotifyControl MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuO
 	else if (a_event->menuName == RE::FaderMenu::MENU_NAME) {
 		if (!a_event->opening)
 			DRS::GetSingleton()->reset = false;
+	}
+	else if (a_event->menuName == RE::RaceSexMenu::MENU_NAME) {
+	 	DRS::GetSingleton()->reset = a_event->opening;
 	}
 
 	return RE::BSEventNotifyControl::kContinue;

--- a/src/DRS.cpp
+++ b/src/DRS.cpp
@@ -38,14 +38,13 @@ void DRS::GetGameSettings()
 
 void DRS::Update()
 {
-	if (reset) {	
+	if (reset) {
 		ResetScale();
-		if (auto ui = RE::UI::GetSingleton(); ui && ui->IsUsingCustomRendering())
-			return;
+		return;
 	}
-
-	if (!(RE::UI::GetSingleton() && RE::UI::GetSingleton()->GameIsPaused()))  // Ignore paused game which skews frametimes
+	else if (const auto ui = RE::UI::GetSingleton(); !(ui && ui->GameIsPaused())) { // Ignore paused game which skews frametimes
 		ControlResolution();
+	}
 }
 
 void DRS::ControlResolution()


### PR DESCRIPTION
This prevents face overlays applied with racemenu from breaking, at least in the little bit of testing i've done. If racemenu is opened or the game is reloaded, they'll break again if the scale factor is less than one.